### PR TITLE
Catch and emit errors from html-minifier

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
-var _ = require('underscore');
+'use strict';
+
+var _       = require('underscore');
 var through = require('through2');
-var minify = require('html-minifier').minify;
+var minify  = require('html-minifier').minify;
 
 var MINIFIER_OPTS = {
   // http://perfectionkills.com/experimenting-with-html-minifier/#options
@@ -13,14 +15,14 @@ var templateExtension = /\.(jst|tpl|html|ejs)$/;
 function compile(str, minifierOpts_, templateOpts_) {
   var templateOpts = templateOpts_;
   var minifierOpts = (minifierOpts_ !== false) ? _.defaults({}, minifierOpts_, MINIFIER_OPTS) : false;
+
   var minified = minifierOpts ? minify(str, minifierOpts) : str;
   var compiled = _.template(minified, null, templateOpts);
   return compiled;
 }
 
-function process(str, minifierOpts_, templateOpts_, engine_) {
+function process(source, engine_) {
   var engine = engine_ || 'underscore';
-  var source = compile(str, minifierOpts_, templateOpts_).source;
   var wrapped = (
     'var _ = require(\'' + engine + '\');\n' +
     'module.exports = ' + source + ';'
@@ -33,13 +35,23 @@ function jstify(file, opts) {
   if (!opts) opts = {};
 
   var buffers = [];
+
   function push(chunk, enc, next) {
     buffers.push(chunk);
     next();
   }
+
   function end(next) {
     var str = Buffer.concat(buffers).toString();
-    var body = process(str, opts.minifierOpts, opts.templateOpts, opts.engine);
+    var compiled;
+
+    try {
+        compiled = compile(str, opts.minifierOpts, opts.templateOpts).source;
+    } catch(e) {
+        return this.emit('error', e);
+    }
+
+    var body = process(compiled, opts.engine);
     this.push(body);
     next();
   }


### PR DESCRIPTION
Errors from `html-minifier` aren't caught and break things like gulp watch or watchify instead of letting the stream handle the error.
