### PR TITLE
New engine with lodash.escape as only runtime dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,18 @@ npm install --save-dev jstify
 
 `jstify` can take a configuration object with any of the following:
 
-* `engine` _(optional)_: The value used for `var _ = require([engine]);` in the template output. The default value is `underscore`, but may be set to `lodash` for example.
+* `engine` _(optional)_: The value used for `var _ = require([engine]);` in the template output. The default value is `underscore`, but may be set to `lodash` for example. Set it to `lodash-micro` to only include `lodash.escape` as a runtime dependency.
 * `withImports` _(optional)_: Whether to simulate Lo-Dash's [`_.templateSettings.imports`](http://lodash.com/docs#templateSettings_imports) in the compiled template. Defaults to `false`.
 * `templateOpts` _(optional)_: The options to pass to `_.template`. By default this is empty, check [Underscore's template docs](http://underscorejs.org/#template) for more options.
 * `minifierOpts` _(optional)_: The options to pass to [HTMLMinifer](https://github.com/kangax/html-minifier). By default, `removeComments` and `collapseWhitespace` are set to `true`, everything else is `false`. See the [HTMLMinifier options docs](http://perfectionkills.com/experimenting-with-html-minifier/#options) for more info.
   * Set to `false` to disable `HTMLMinifier` (This is useful for when your template looks like broken markup and the minifier is complaining).
 
 The transform is only be applied to `.ejs`, `.tpl`, `.jst`, or `.html` files.
+
+#### Usage of `engine=lodash-micro` ####
+
+When file size of the compiled template is critical use `lodash-micro` configuration for `engine`. As `lodash.escape` is the only runtime dependency, this reduces the minified file size to less than 1kb. This should only be used when the template is not using any `underscore` or `lodash` functions inline like `_.each`.
+
 
 ### Usage ###
 

--- a/index.js
+++ b/index.js
@@ -23,21 +23,27 @@ function compile(str, minifierOpts_, templateOpts_) {
 
 function process(source, engine_, withImports) {
   var engine = engine_ || 'underscore';
+  var engineRequire = 'var _ = require(\'' + engine + '\');\n';
+
+  if (engine === 'lodash-micro') {
+    // Micro template option, where only lodash.escpae is required, this gives
+    // a very small file size footprint compared to include underscore/lodash.
+    // It requires the template to not use any lodash/underscore functions.
+    engineRequire = 'var _ = {escape: require("lodash.escape")};\n';
+  }
+
   if (withImports) {
       // This is roughly what Lo-Dash does to bring in `imports`:
       // https://github.com/lodash/lodash/blob/2.4.1/lodash.js#L6672
     return (
-      'var _ = require(\'' + engine + '\');\n' +
+      engineRequire +
       // The template is written as an actual function first so that
       // it can take advantage of any minification. It is then turned
       // into a string because that's what `Function` takes.
       'module.exports = Function(_.keys(_.templateSettings.imports), \'return \' + ' + source + '.toString()).apply(undefined, _.values(_.templateSettings.imports));\n'
     );
   } else {
-    return (
-      'var _ = require(\'' + engine + '\');\n' +
-      'module.exports = ' + source + ';\n'
-    );
+    return engineRequire + 'module.exports = ' + source + ';\n';
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -32,13 +32,13 @@ function process(source, engine_, withImports) {
     engineRequire = 'var _ = {escape: require("lodash.escape")};\n';
 
     if (withImports) {
-      this.emit('error', 'Cannot use "withImports" together with "lodash-micro"');
+      throw new Error('Cannot use "withImports" together with "lodash-micro"');
     }
   }
 
   if (withImports) {
-      // This is roughly what Lo-Dash does to bring in `imports`:
-      // https://github.com/lodash/lodash/blob/2.4.1/lodash.js#L6672
+    // This is roughly what Lo-Dash does to bring in `imports`:
+    // https://github.com/lodash/lodash/blob/2.4.1/lodash.js#L6672
     return (
       engineRequire +
       // The template is written as an actual function first so that
@@ -67,13 +67,13 @@ function jstify(file, opts) {
     var compiled;
 
     try {
-        compiled = compile(str, opts.minifierOpts, opts.templateOpts).source;
+      compiled = compile(str, opts.minifierOpts, opts.templateOpts).source;
+      var body = process(compiled, opts.engine, opts.withImports);
+      this.push(body);
     } catch(e) {
-        return this.emit('error', e);
+      return this.emit('error', e);
     }
 
-    var body = process(compiled, opts.engine, opts.withImports);
-    this.push(body);
     next();
   }
 

--- a/index.js
+++ b/index.js
@@ -30,6 +30,10 @@ function process(source, engine_, withImports) {
     // a very small file size footprint compared to include underscore/lodash.
     // It requires the template to not use any lodash/underscore functions.
     engineRequire = 'var _ = {escape: require("lodash.escape")};\n';
+
+    if (withImports) {
+      this.emit('error', 'Cannot use "withImports" together with "lodash-micro"');
+    }
   }
 
   if (withImports) {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "dependencies": {
     "html-minifier": "^0.6.8",
     "through2": "^0.6.3",
-    "underscore": "^1.7.0"
+    "underscore": "^1.7.0",
+    "lodash.escape": "~3.0.0"
   },
   "devDependencies": {
     "concat-stream": "^1.4.6",

--- a/test/test.js
+++ b/test/test.js
@@ -59,6 +59,21 @@ test('jstify', function(t) {
     });
   });
 
+  t.test('with lodash-micro as engine', function(t) {
+    t.plan(2);
+    var filename = path.resolve('test/fixtures/index.tpl');
+    var opts = {engine: 'lodash-micro'};
+    jstifier(filename, opts, function(output) {
+      var template = loadAsModule(output);
+      t.equal(template(),
+        '<div><p>i like red bull and cat gifs</p></div>',
+        'should work');
+      t.ok(
+        startsWith(output, 'var _ = {escape: require("lodash.escape")};'),
+        'should only require lodash.escape');
+    });
+  });
+
   t.test('no collapseWhitespace', function(t) {
     t.plan(1);
     var filename = path.resolve('test/fixtures/index.tpl');


### PR DESCRIPTION
Currently `jstify` adds a line `var _ = require([engine]);` in the output. This means that the entire `lodash` or `underscore` library is included when browserify bundles the file. But actually the only runtime dependency is the `escape` function (unless if the template uses other functions from `underscore`, etc).

For me the idea about precompilation using `jstify` makes most sense if it reduces the runtime dependency and removes the `_.template` step. So why not just include the `escape` function? The awesome modularized builds of `lodash` allows this, see https://www.npmjs.com/package/lodash.escape

This pull requests adds a new `lodash-micro` option for the engine that reduces the final bundle size from 40-100 kb (depending on engine) to < 1kb. Solves https://github.com/zertosh/jstify/issues/3

For me this could be the default engine option, but I don't know all the use cases of this transformer. :)