### PR TITLE
Update HTML minifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "git://github.com/zertosh/jstify.git"
   },
   "dependencies": {
-    "html-minifier": "^0.6.8",
+    "html-minifier": "^0.7.2",
     "through2": "^0.6.3",
     "underscore": "^1.7.0",
     "lodash.escape": "~3.0.0"


### PR DESCRIPTION
Version ~0.6.0 of HTML minifier does not handle SVG correctly. Updating to ~0.7.0 fixes those issues.

Tests pass.

Cheers! :beers: 