### PR TITLE
Add conservativeCollapse to defaults

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ var minify  = require('html-minifier').minify;
 var MINIFIER_OPTS = {
   // http://perfectionkills.com/experimenting-with-html-minifier/#options
   removeComments: true,
-  collapseWhitespace: true
+  collapseWhitespace: true,
+  conservativeCollapse: true
 };
 
 var templateExtension = /\.(jst|tpl|html|ejs)$/;

--- a/test/fixtures/index.tpl
+++ b/test/fixtures/index.tpl
@@ -1,3 +1,5 @@
-<div>
-    <p><%= "i like red bull and cat gifs" %></p>
-        </div>
+<!-- Some comment --><div>
+
+  <p><%= "i like red bull" %> <%= "and cat gifs" %></p>
+
+  </div>

--- a/test/test.js
+++ b/test/test.js
@@ -36,7 +36,7 @@ test('jstify', function(t) {
     jstifier(filename, null, function(output) {
       var template = loadAsModule(output);
       t.equal(template(),
-        '<div><p>i like red bull and cat gifs</p></div>',
+        '<div> <p>i like red bull and cat gifs</p> </div>',
         'should work');
       t.ok(
         startsWith(output, 'var _ = require(\'underscore\');'),
@@ -51,7 +51,7 @@ test('jstify', function(t) {
     jstifier(filename, opts, function(output) {
       var template = loadAsModule(output);
       t.equal(template(),
-        '<div><p>i like red bull and cat gifs</p></div>',
+        '<div> <p>i like red bull and cat gifs</p> </div>',
         'should work');
       t.ok(
         startsWith(output, 'var _ = require(\'lodash\');'),
@@ -66,23 +66,11 @@ test('jstify', function(t) {
     jstifier(filename, opts, function(output) {
       var template = loadAsModule(output);
       t.equal(template(),
-        '<div><p>i like red bull and cat gifs</p></div>',
+        '<div> <p>i like red bull and cat gifs</p> </div>',
         'should work');
       t.ok(
         startsWith(output, 'var _ = {escape: require("lodash.escape")};'),
         'should only require lodash.escape');
-    });
-  });
-
-  t.test('no collapseWhitespace', function(t) {
-    t.plan(1);
-    var filename = path.resolve('test/fixtures/index.tpl');
-    var opts = {minifierOpts: {collapseWhitespace: false}};
-    jstifier(filename, opts, function(output) {
-      var template = loadAsModule(output);
-      t.equal(template(),
-        '<div>\n    <p>i like red bull and cat gifs</p>\n        </div>',
-        'should work');
     });
   });
 
@@ -148,6 +136,30 @@ test('jstify', function(t) {
     });
   });
 
+  t.test('no collapseWhitespace', function(t) {
+    t.plan(1);
+    var filename = path.resolve('test/fixtures/index.tpl');
+    var opts = {minifierOpts: {collapseWhitespace: false}};
+    jstifier(filename, opts, function(output) {
+      var template = loadAsModule(output);
+      t.equal(template(),
+        '<div>\n\n  <p>i like red bull and cat gifs</p>\n\n  </div>',
+        'should work');
+    });
+  });
+
+  t.test('no conservativeCollapse', function(t) {
+    t.plan(1);
+    var filename = path.resolve('test/fixtures/index.tpl');
+    var opts = {minifierOpts: {conservativeCollapse: false}};
+    jstifier(filename, opts, function(output) {
+      var template = loadAsModule(output);
+      t.equal(template(),
+        '<div><p>i like red bulland cat gifs</p></div>',
+        'should work');
+    });
+  });
+
   t.test('compile()', function(t) {
     t.plan(1);
     var filename = path.resolve('test/fixtures/index.tpl');
@@ -155,7 +167,7 @@ test('jstify', function(t) {
       .pipe(concat({encoding: 'string'}, function(data) {
         var template = jstify.compile(data);
         t.equal(template(),
-          '<div><p>i like red bull and cat gifs</p></div>',
+          '<div> <p>i like red bull and cat gifs</p> </div>',
           'should work');
       }));
   });


### PR DESCRIPTION
Hey, another issue with the minifier came up :)

We had something like:
```html
<div><%= "Jim" %> is cool</div>
```
and it was rendering as:
```html
<div>Jimis cool</div>
```

Turned out the HTML minifier was seeing the Underscore delimiter as markup and collapsing white space around it. This was pretty surprising and took some time to figure out.

This PR is to remove `collapseWhitespace` as a minifier default so no one else gets bit. :)

Cheers! :beers: 