### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jstify",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Browserify transform for pre-compiled Underscore and Lo-Dash templates (with HTML minification)",
   "keywords": [
     "template",
@@ -21,14 +21,14 @@
     "url": "git://github.com/zertosh/jstify.git"
   },
   "dependencies": {
-    "html-minifier": "^0.7.2",
-    "through2": "^0.6.3",
-    "underscore": "^1.7.0",
-    "lodash.escape": "~3.0.0"
+    "html-minifier": "^1.0.0",
+    "lodash.escape": "^3.0.0",
+    "through2": "^2.0.0",
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
-    "concat-stream": "^1.4.6",
-    "tape": "^3.0.0"
+    "concat-stream": "^1.5.1",
+    "tape": "^4.2.2"
   },
   "engines": {
     "node": ">=0.10"


### PR DESCRIPTION
This change removes Underscore for Lodash. Underscore has been in developmental limbo for a while and Lodash is faster with more features. Using Lodash as the default also allows us to remove `lodash.escape` from our dependencies. 

Also updated dependencies (like html-minifier to 1.0).