### PR TITLE
enable use of global underscore/lodash

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install --save-dev jstify
 
 `jstify` can take a configuration object with any of the following:
 
-* `engine` _(optional)_: The value used for `var _ = require([engine]);` in the template output. The default value is `underscore`, but may be set to `lodash` for example. Set it to `lodash-micro` to only include `lodash.escape` as a runtime dependency.
+* `engine` _(optional)_: The value used for `var _ = require([engine]);` in the template output. The default value is `underscore`, but may be set to `lodash` for example. Set it to `lodash-micro` to only include `lodash.escape` as a runtime dependency. Set it to `global` if using a CDN or a separate bundle that exposes the engine required as a global.
 * `withImports` _(optional)_: Whether to simulate Lo-Dash's [`_.templateSettings.imports`](http://lodash.com/docs#templateSettings_imports) in the compiled template. Defaults to `false`.
 * `templateOpts` _(optional)_: The options to pass to `_.template`. By default this is empty, check [Underscore's template docs](http://underscorejs.org/#template) for more options.
 * `minifierOpts` _(optional)_: The options to pass to [HTMLMinifer](https://github.com/kangax/html-minifier). By default, `removeComments`, `collapseWhitespace` and `conservativeCollapse` are set to `true`, everything else is `false`. See the [HTMLMinifier options docs](http://perfectionkills.com/experimenting-with-html-minifier/#options) for more info.

--- a/index.js
+++ b/index.js
@@ -40,6 +40,8 @@ function wrap(source, engine, withImports) {
     if (withImports) {
       throw new Error('Cannot use "withImports" together with "lodash-micro"');
     }
+  } else if (engine === 'global') {
+    engineRequire = '';
   }
 
   if (withImports) {


### PR DESCRIPTION
This PR enables you to use a global underscore/lodash library instead of requiring it in to the bundle.

This is useful if loading underscore/lodash from a CDN or a separate bundle that exposes the library as a global as it prevents duplicating the dependency.
