### PR TITLE
Fix the version of html-minifier to v1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "tap test/*.js"
   },
   "dependencies": {
-    "html-minifier": "^1.0.0",
+    "html-minifier": "1.1.1",
     "underscore": "^1.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello

I found some strange behaviour of the latest version of `html-minifier` and I think it potentially breaks the code which depends on `jstify`.

`html-minifier` (until v1.1.1) used to render the string `<h1><%- foo %></h1>` like the following:

```
> require('html-minifier').minify('<h1><%- foo %></h1>', {collapseWhitespace: true, conservativeCollapse: true})
'<h1><%- foo %></h1>'
```

Now (v1.2.0) it renders it like the following:

```
> require('html-minifier').minify('<h1><%- foo %></h1>', {collapseWhitespace: true, conservativeCollapse: true})
'<h1> <%- foo %> </h1>'
```

In another case `<img src="<%- basePath %><%- path %>">` is rendered `<img src="<%- basePath %> <%- path %>">` with v1.2.0. (it used to be rendered `<img src="<%- basePath %><%- path %>">` with v1.1.1)

My suggestion is to fix the version of `html-minifier` v1.1.1 for the moment.

I checked the test cases and found that all tests passed with v1.1.1 and 7 failed with v1.2.0.
